### PR TITLE
Refactor conversation interruption API

### DIFF
--- a/test_interruptible_conversation.py
+++ b/test_interruptible_conversation.py
@@ -8,7 +8,7 @@ import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from audio_interrupt import AudioInterruptHandler
-from conversation_manager import ConversationManager
+from conversation_manager import ConversationManager, ConversationState
 import numpy as np
 import time
 
@@ -79,9 +79,9 @@ def test_integration():
     conversation_manager = ConversationManager()
 
     # Register callback
-    def on_state_change(state, context):
-        print(f"🔄 State changed to: {state}")
-        if state == "interrupted":
+    def on_state_change(context):
+        print(f"🔄 State changed to: {context.current_state.value}")
+        if context.current_state == ConversationState.INTERRUPTED:
             audio_handler.interrupt_playback()
 
     conversation_manager.register_state_callback(on_state_change)


### PR DESCRIPTION
## Summary
- Adopt new conversation API in voice_assistant including context-aware state callbacks and response management
- Detect user speech during playback to interrupt responses
- Update tests for revised `register_state_callback` signature

## Testing
- `pytest` *(fails: PortAudio library not found)*
- `apt-get install -y portaudio19-dev` *(package not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b20073bddc832384aa7d4ba9523969