### PR TITLE
feat: stream in-memory whisper transcription

### DIFF
--- a/scripts/benchmark_transcription.py
+++ b/scripts/benchmark_transcription.py
@@ -1,0 +1,35 @@
+import os
+import time
+import numpy as np
+import pathlib
+import sys
+
+# Ensure repository src is on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+os.environ.setdefault("MACBOT_DISABLE_TTS", "1")
+
+from macbot.voice_assistant import (  # type: ignore
+    SAMPLE_RATE,
+    _WHISPER_IMPL,
+    transcribe,
+    _transcribe_cli,
+)
+
+
+def benchmark() -> None:
+    audio = np.random.randn(SAMPLE_RATE).astype(np.float32)
+
+    start = time.perf_counter()
+    transcribe(audio)
+    end = time.perf_counter()
+    print(f"in-memory ({_WHISPER_IMPL}): {end - start:.3f}s")
+
+    start = time.perf_counter()
+    _transcribe_cli(audio)
+    end = time.perf_counter()
+    print(f"cli fallback: {end - start:.3f}s")
+
+
+if __name__ == "__main__":
+    benchmark()


### PR DESCRIPTION
## Summary
- use Python bindings when available for Whisper transcription and fall back to CLI
- support incremental chunk streaming with `StreamingTranscriber`
- add simple benchmarking script for comparing in-memory vs CLI latency

## Testing
- `python scripts/benchmark_transcription.py`
- `MACBOT_DISABLE_TTS=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdf3f1dec88323af1d370cedc4cd9a