### PR TITLE
Refactor MessageBusClient for network protocol with auto-reconnect

### DIFF
--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,71 +1,136 @@
-#!/usr/bin/env python3
-"""
-Test script for MacBot Message Bus System
-"""
-import sys
-import os
-import time
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+"""Tests for MessageBusClient network resilience."""
 
-from macbot.message_bus import MessageBus, start_message_bus, stop_message_bus
+import threading
+import time
+from typing import Callable, Dict, List
+
+from websockets.sync.server import serve
+
 from macbot.message_bus_client import MessageBusClient
 
-def test_message_bus():
-    """Test the message bus system"""
-    print("🧪 Testing MacBot Message Bus System...")
 
-    # Start message bus
-    print("1. Starting message bus server...")
-    bus = start_message_bus(host='localhost', port=8082)
+class TestServer:
+    """Simple broadcast WebSocket server using synchronous API."""
 
-    # Create test clients
-    print("2. Creating test clients...")
-    client1 = MessageBusClient(
-        host='localhost',
-        port=8082,
-        service_type='test_service_1'
+    def __init__(self, host: str = "127.0.0.1", port: int = 8765):
+        self.host = host
+        self.port = port
+        self.clients: List = []
+        self.thread: threading.Thread | None = None
+        self.server = None
+
+    def _handler(self, websocket):
+        self.clients.append(websocket)
+        try:
+            for message in websocket:
+                for ws in list(self.clients):
+                    try:
+                        ws.send(message)
+                    except Exception:
+                        pass
+        finally:
+            if websocket in self.clients:
+                self.clients.remove(websocket)
+
+    def start(self) -> None:
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
+        time.sleep(0.1)
+
+    def _run(self) -> None:
+        with serve(self._handler, self.host, self.port) as server:
+            self.server = server
+            server.serve_forever()
+
+    def stop(self) -> None:
+        self.drop_connections()
+        if self.server:
+            self.server.shutdown()
+        if self.thread:
+            self.thread.join()
+        self.thread = None
+        self.server = None
+        self.clients = []
+
+    def drop_connections(self) -> None:
+        for ws in list(self.clients):
+            try:
+                ws.close()
+            except Exception:
+                pass
+
+
+def wait_for(condition: Callable[[], bool], timeout: float = 5.0) -> bool:
+    start = time.time()
+    while time.time() - start < timeout:
+        if condition():
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def create_client(port: int, events: List[str], messages: List[Dict]) -> MessageBusClient:
+    client = MessageBusClient(
+        host="127.0.0.1",
+        port=port,
+        service_type="test",
+        heartbeat_interval=0.5,
+        heartbeat_timeout=0.5,
+        reconnect_initial=0.1,
+        reconnect_max=1.0,
+        on_disconnect=lambda: events.append("disconnected"),
+        on_reconnect=lambda: events.append("reconnected"),
     )
-    client2 = MessageBusClient(
-        host='localhost',
-        port=8082,
-        service_type='test_service_2'
-    )
+    client.register_handler("test", lambda m: messages.append(m))
+    return client
 
-    # Start clients
-    print("3. Starting clients...")
-    client1.start()
-    client2.start()
 
-    # Wait for connections
-    time.sleep(3)
+def test_reconnect_on_server_restart():
+    server = TestServer(port=8765)
+    server.start()
 
-    # Test message sending
-    print("4. Testing message exchange...")
+    events: List[str] = []
+    messages: List[Dict] = []
+    client = create_client(8765, events, messages)
+    client.start()
 
-    # Client 1 sends message
-    client1.send_message({
-        'type': 'test_message',
-        'content': 'Hello from client 1!',
-        'timestamp': time.time()
-    })
+    assert wait_for(lambda: client.is_connected())
+    client.send_message({"type": "test", "content": "hello"})
+    assert wait_for(lambda: len(messages) == 1)
 
-    # Client 2 sends message
-    client2.send_message({
-        'type': 'test_message',
-        'content': 'Hello from client 2!',
-        'timestamp': time.time()
-    })
+    server.stop()
+    assert wait_for(lambda: "disconnected" in events)
 
-    # Wait for messages to be processed
-    time.sleep(2)
+    server.start()
+    assert wait_for(lambda: events.count("reconnected") >= 1)
 
-    print("5. Test completed successfully!")
-    print("✅ Message bus system is working properly")
+    client.send_message({"type": "test", "content": "again"})
+    assert wait_for(lambda: len(messages) == 2)
 
-    # Cleanup
-    client1.stop()
-    client2.stop()
-    stop_message_bus()
+    client.stop()
+    server.stop()
 
-if __name__ == "__main__":
-    test_message_bus()
+
+def test_reconnect_on_network_drop():
+    server = TestServer(port=8766)
+    server.start()
+
+    events: List[str] = []
+    messages: List[Dict] = []
+    client = create_client(8766, events, messages)
+    client.start()
+
+    assert wait_for(client.is_connected)
+    client.send_message({"type": "test", "content": "hello"})
+    assert wait_for(lambda: len(messages) == 1)
+
+    server.drop_connections()
+    assert wait_for(lambda: "disconnected" in events)
+    assert wait_for(lambda: events.count("reconnected") >= 1)
+
+    client.send_message({"type": "test", "content": "hello again"})
+    assert wait_for(lambda: len(messages) == 2)
+
+    client.stop()
+    server.stop()
+


### PR DESCRIPTION
## Summary
- Switch MessageBusClient to use WebSocket network protocol with heartbeat pings and exponential backoff reconnect
- Add connection loss and restoration callbacks
- Add tests covering server restarts and network drops

## Testing
- `pytest tests/test_message_bus.py`
- `pytest` *(fails: OSError: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf3ee3fb883239ad52729f7209fdd