### PR TITLE
Refactor async TTS playback and add barge-in test

### DIFF
--- a/src/macbot/voice_assistant.py
+++ b/src/macbot/voice_assistant.py
@@ -444,36 +444,58 @@ else:
 def speak(text: str):
     """Speak text using interruptible TTS system"""
     if INTERRUPTION_ENABLED and audio_handler and conversation_manager:
-        try:
-            conversation_manager.start_response(text)
-
-            # Use pyttsx3 for TTS with interruption capability
-            def on_start(name):
-                pass
-
-            def on_end(name):
-                if (
-                    conversation_manager
-                    and conversation_manager.current_context
-                    and conversation_manager.current_context.current_state
-                    != ConversationState.INTERRUPTED
-                ):
-                    conversation_manager.complete_response()
-
-            tts_engine.connect('started-utterance', on_start)
-            tts_engine.connect('finished-utterance', on_end)
-
-            tts_engine.say(text)
-            tts_engine.runAndWait()
-
-        except Exception as e:
-            print(f"Interruptible TTS Error: {e}")
-            # Fallback to original blocking method
+        def tts_worker(full_text: str):
             try:
-                tts_engine.say(text)
-                tts_engine.runAndWait()
-            except Exception as e2:
-                print(f"Fallback TTS also failed: {e2}")
+                conversation_manager.start_response(full_text)
+
+                # Generate TTS audio into a temporary wav file
+                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+                    tmp_path = f.name
+                try:
+                    tts_engine.save_to_file(full_text, tmp_path)
+                    tts_engine.runAndWait()
+                    audio, sr = sf.read(tmp_path, dtype="float32")
+                finally:
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        pass
+
+                chunk_size = int(sr * 0.25)  # 250ms chunks
+                total_samples = len(audio)
+                idx = 0
+
+                while idx < total_samples:
+                    if (
+                        conversation_manager.current_context
+                        and conversation_manager.current_context.current_state
+                        == ConversationState.INTERRUPTED
+                    ):
+                        # Buffer remaining text for resume
+                        remaining_ratio = idx / total_samples
+                        remaining_index = int(len(full_text) * remaining_ratio)
+                        with conversation_manager.lock:
+                            ctx = conversation_manager.current_context
+                            if ctx:
+                                ctx.buffered_response = full_text[remaining_index:]
+                                ctx.ai_response = full_text[:remaining_index]
+                        return
+
+                    chunk = audio[idx : idx + chunk_size]
+                    audio_handler.play_audio(chunk)
+                    idx += len(chunk)
+
+                    spoken_chars = int(len(full_text) * idx / total_samples)
+                    conversation_manager.update_response(full_text[:spoken_chars])
+
+                conversation_manager.update_response(full_text)
+                conversation_manager.complete_response()
+
+            except Exception as e:
+                logger.error(f"Interruptible TTS Error: {e}")
+
+        threading.Thread(target=tts_worker, args=(text,), daemon=True).start()
+
     else:
         # Original blocking TTS when interruption is disabled
         try:

--- a/tests/test_barge_in.py
+++ b/tests/test_barge_in.py
@@ -1,0 +1,80 @@
+import threading
+import time
+import numpy as np
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from macbot.conversation_manager import ConversationManager, ConversationState
+
+SAMPLE_RATE = 24000
+
+
+class DummyAudioHandler:
+    """Simulates AudioInterruptHandler for testing."""
+
+    def __init__(self, sample_rate):
+        self.sample_rate = sample_rate
+        self.interrupt_requested = False
+
+    def play_audio(self, audio_data, on_interrupt=None):
+        duration = len(audio_data) / self.sample_rate
+        start = time.time()
+        while time.time() - start < duration:
+            if self.interrupt_requested:
+                if on_interrupt:
+                    on_interrupt()
+                return False
+            time.sleep(0.01)
+        return True
+
+    def interrupt_playback(self):
+        self.interrupt_requested = True
+
+
+def async_speak(handler, cm, text):
+    t = np.linspace(0, 3.0, int(SAMPLE_RATE * 3.0), False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+    chunk = int(SAMPLE_RATE * 0.25)
+    total = len(audio)
+    idx = 0
+    cm.start_response(text)
+    while idx < total:
+        if cm.current_context.current_state == ConversationState.INTERRUPTED:
+            remaining_index = int(len(text) * idx / total)
+            cm.current_context.buffered_response = text[remaining_index:]
+            cm.current_context.ai_response = text[:remaining_index]
+            return
+        piece = audio[idx : idx + chunk]
+        handler.play_audio(piece)
+        idx += len(piece)
+        spoken = int(len(text) * idx / total)
+        cm.update_response(text[:spoken])
+    cm.update_response(text)
+    cm.complete_response()
+
+
+def test_barge_in_during_long_response():
+    handler = DummyAudioHandler(SAMPLE_RATE)
+    cm = ConversationManager()
+    cm.start_conversation()
+    long_text = "hello " * 100
+
+    def interrupter():
+        time.sleep(0.2)
+        cm.interrupt_response()
+        handler.interrupt_playback()
+
+    threading.Thread(target=interrupter).start()
+    async_speak(handler, cm, long_text)
+
+    assert cm.current_context.current_state == ConversationState.INTERRUPTED
+
+    remaining = cm.resume_response()
+    assert remaining
+
+    async_speak(handler, cm, remaining)
+
+    assert cm.current_context.current_state == ConversationState.IDLE
+    assert cm.current_context.ai_response == long_text


### PR DESCRIPTION
## Summary
- stream TTS output in chunks and feed into `AudioInterruptHandler` without blocking
- buffer remaining text on interruption for resume
- add integration test exercising barge-in during a long response

## Testing
- `pytest tests/test_barge_in.py::test_barge_in_during_long_response -q` *(fails: hung in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf3f6e0488323b68fb233bf105c19