### PR TITLE
feat: add network message bus

### DIFF
--- a/src/macbot/message_bus.py
+++ b/src/macbot/message_bus.py
@@ -1,131 +1,261 @@
 #!/usr/bin/env python3
+"""Network based message bus used by MacBot services.
+
+This implementation exposes a simple TCP server that accepts connections from
+external processes.  Clients communicate with the server using a newline
+delimited JSON protocol.  Every client must first send a ``register`` message::
+
+    {"action": "register", "client_id": "id", "service_type": "type"}
+
+Once registered, clients can send messages to other clients or broadcast
+messages to all connected clients.  Messages are routed according to the
+``target_client`` or ``target_service`` fields.  Routed messages are delivered
+to clients in the following format::
+
+    {
+        "action": "message",
+        "from": "sender_id",
+        "from_service": "sender_service_type",
+        "message": {"type": "...", ...}
+    }
+
+This module replaces the previous in-memory message bus allowing components to
+communicate across process boundaries.
 """
-MacBot Message Bus - Simplified real-time communication system for all services
-"""
+
+from __future__ import annotations
+
 import json
 import logging
+import socket
 import threading
-import queue
-import time
-from typing import Dict, List, Callable, Any, Optional
-from datetime import datetime
+from typing import Dict, Optional
+
 
 logger = logging.getLogger(__name__)
 
-class MessageBus:
-    """Simplified message bus for real-time service communication"""
 
-    def __init__(self, host: str = "localhost", port: int = 8082):
+class MessageBus:
+    """TCP based message bus."""
+
+    def __init__(self, host: str = "localhost", port: int = 8082) -> None:
         self.host = host
         self.port = port
-        self.clients: Dict[str, Dict] = {}  # client_id -> {service_type, last_seen, message_queue}
-        self.message_handlers: Dict[str, List[Callable]] = {}
+        self.server_socket: Optional[socket.socket] = None
+        # client_id -> {service_type, socket, file}
+        self.clients: Dict[str, Dict[str, object]] = {}
+        self.lock = threading.Lock()
         self.running = False
-        self.thread = None
-        self.message_queue = queue.Queue()
+        self.thread: Optional[threading.Thread] = None
 
-    def start(self):
-        """Start the message bus"""
+    # ------------------------------------------------------------------
+    # Lifecycle management
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Start the TCP server in a background thread."""
+        if self.running:
+            return
+
+        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server_socket.bind((self.host, self.port))
+        # When port is 0 the OS chooses a free port - capture the actual value.
+        self.port = self.server_socket.getsockname()[1]
+        self.server_socket.listen()
+
         self.running = True
-        self.thread = threading.Thread(target=self._process_messages, daemon=True)
+        self.thread = threading.Thread(target=self._accept_loop, daemon=True)
         self.thread.start()
-        logger.info(f"Message bus started on {self.host}:{self.port}")
+        logger.info("Message bus started on %s:%s", self.host, self.port)
 
-    def stop(self):
-        """Stop the message bus"""
+    def stop(self) -> None:
+        """Stop the TCP server and close all client connections."""
         self.running = False
+
+        if self.server_socket is not None:
+            try:
+                self.server_socket.close()
+            except OSError:
+                pass
+
+        # Close all client sockets
+        with self.lock:
+            for info in self.clients.values():
+                try:
+                    sock = info.get("socket")
+                    if sock:
+                        sock.close()
+                except OSError:
+                    pass
+            self.clients.clear()
+
         if self.thread:
             self.thread.join(timeout=5)
+
         logger.info("Message bus stopped")
 
-    def register_client(self, client_id: str, service_type: str) -> queue.Queue:
-        """Register a new client and return its message queue"""
-        client_queue = queue.Queue()
-        self.clients[client_id] = {
-            'service_type': service_type,
-            'last_seen': datetime.now(),
-            'message_queue': client_queue
-        }
-        logger.info(f"Client registered: {service_type} ({client_id})")
-        return client_queue
-
-    def unregister_client(self, client_id: str):
-        """Unregister a client"""
-        if client_id in self.clients:
-            del self.clients[client_id]
-            logger.info(f"Client unregistered: {client_id}")
-
-    def send_message(self, message: dict, target_client: Optional[str] = None, target_service: Optional[str] = None):
-        """Send a message to specific client or service type"""
-        if target_client and target_client in self.clients:
-            # Send to specific client
-            self.clients[target_client]['message_queue'].put(message)
-        elif target_service:
-            # Send to all clients of specific service type
-            sent = 0
-            for client_id, client_info in self.clients.items():
-                if client_info['service_type'] == target_service:
-                    client_info['message_queue'].put(message)
-                    sent += 1
-            if sent == 0:
-                logger.warning(f"No clients found for service type: {target_service}")
-        else:
-            # Broadcast to all clients
-            for client_id, client_info in self.clients.items():
-                client_info['message_queue'].put(message)
-
-    def broadcast(self, message: dict, exclude_client: Optional[str] = None):
-        """Broadcast message to all clients except excluded one"""
-        for client_id, client_info in self.clients.items():
-            if client_id != exclude_client:
-                client_info['message_queue'].put(message)
-
-    def _process_messages(self):
-        """Process messages in the background"""
+    # ------------------------------------------------------------------
+    # Networking helpers
+    # ------------------------------------------------------------------
+    def _accept_loop(self) -> None:
+        """Accept incoming client connections."""
+        assert self.server_socket is not None
         while self.running:
             try:
-                # Process any queued messages (for future use)
-                time.sleep(0.1)
-            except Exception as e:
-                logger.error(f"Message processing error: {e}")
+                client_sock, _addr = self.server_socket.accept()
+            except OSError:
+                break
 
-    def get_clients_by_service_type(self, service_type: str) -> List[str]:
-        """Get all client IDs for a specific service type"""
-        return [client_id for client_id, info in self.clients.items() 
-                if info['service_type'] == service_type]
+            thread = threading.Thread(
+                target=self._handle_client, args=(client_sock,), daemon=True
+            )
+            thread.start()
 
-    def get_service_status(self) -> Dict[str, Any]:
-        """Get status of all services"""
-        status = {}
-        for service_type in set(info['service_type'] for info in self.clients.values()):
-            clients = self.get_clients_by_service_type(service_type)
-            status[service_type] = {
-                'count': len(clients),
-                'clients': clients,
-                'last_seen': max((info['last_seen'] for info in self.clients.values() 
-                                if info['service_type'] == service_type), default=None)
-            }
-        return status
+    def _handle_client(self, sock: socket.socket) -> None:
+        """Handle communication with a single client."""
+        file = sock.makefile(mode="rw", encoding="utf-8")
+        client_id = None
+        try:
+            # Expect registration message first
+            line = file.readline()
+            if not line:
+                return
+            data = json.loads(line)
+            if data.get("action") != "register":
+                return
+
+            client_id = data["client_id"]
+            service_type = data.get("service_type", "unknown")
+            with self.lock:
+                self.clients[client_id] = {
+                    "service_type": service_type,
+                    "socket": sock,
+                    "file": file,
+                }
+
+            # Acknowledge registration
+            self._send_raw(file, {"action": "registered"})
+
+            while self.running:
+                line = file.readline()
+                if not line:
+                    break
+                try:
+                    message = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("Invalid JSON from %s", client_id)
+                    continue
+
+                action = message.get("action")
+                if action == "send":
+                    self._route_message(
+                        sender_id=client_id,
+                        sender_service=service_type,
+                        payload=message.get("message", {}),
+                        target_client=message.get("target_client"),
+                        target_service=message.get("target_service"),
+                    )
+                elif action == "broadcast":
+                    self._broadcast(
+                        sender_id=client_id,
+                        sender_service=service_type,
+                        payload=message.get("message", {}),
+                    )
+        except Exception as exc:  # pragma: no cover - defensive programming
+            logger.exception("Client handler error: %s", exc)
+        finally:
+            if client_id:
+                with self.lock:
+                    self.clients.pop(client_id, None)
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+    # ------------------------------------------------------------------
+    # Message routing helpers
+    # ------------------------------------------------------------------
+    def _send_raw(self, file, data: Dict) -> None:
+        file.write(json.dumps(data) + "\n")
+        file.flush()
+
+    def _route_message(
+        self,
+        sender_id: str,
+        sender_service: str,
+        payload: Dict,
+        target_client: Optional[str] = None,
+        target_service: Optional[str] = None,
+    ) -> None:
+        """Route a message to a target client or service type."""
+
+        message = {
+            "action": "message",
+            "from": sender_id,
+            "from_service": sender_service,
+            "message": payload,
+        }
+
+        if target_client:
+            with self.lock:
+                client = self.clients.get(target_client)
+            if client:
+                self._send_raw(client["file"], message)
+            else:
+                logger.warning("Unknown target client: %s", target_client)
+        elif target_service:
+            sent = 0
+            with self.lock:
+                targets = [
+                    info
+                    for info in self.clients.values()
+                    if info["service_type"] == target_service
+                ]
+            for info in targets:
+                self._send_raw(info["file"], message)
+                sent += 1
+            if sent == 0:
+                logger.warning("No clients found for service type: %s", target_service)
+        else:
+            self._broadcast(sender_id, sender_service, payload)
+
+    def _broadcast(
+        self, sender_id: str, sender_service: str, payload: Dict
+    ) -> None:
+        message = {
+            "action": "message",
+            "from": sender_id,
+            "from_service": sender_service,
+            "message": payload,
+        }
+
+        with self.lock:
+            for cid, info in self.clients.items():
+                if cid != sender_id:
+                    self._send_raw(info["file"], message)
 
 
-# Global message bus instance
-message_bus = None
+# Global message bus instance -------------------------------------------------
+
+message_bus: Optional[MessageBus] = None
 
 
 def start_message_bus(host: str = "localhost", port: int = 8082) -> MessageBus:
-    """Start the global message bus"""
+    """Start the global message bus server."""
     global message_bus
-    message_bus = MessageBus(host, port)
-    message_bus.start()
-    return message_bus
+    bus = MessageBus(host, port)
+    bus.start()
+    message_bus = bus
+    return bus
 
 
-def stop_message_bus():
-    """Stop the global message bus"""
+def stop_message_bus() -> None:
+    """Stop the global message bus server."""
     global message_bus
-    if message_bus:
+    if message_bus is not None:
         message_bus.stop()
+        message_bus = None
 
 
-# Export the main classes and functions
-__all__ = ['MessageBus', 'start_message_bus', 'stop_message_bus']
+__all__ = ["MessageBus", "start_message_bus", "stop_message_bus"]
+

--- a/src/macbot/message_bus_client.py
+++ b/src/macbot/message_bus_client.py
@@ -1,136 +1,156 @@
 #!/usr/bin/env python3
-"""
-MacBot Message Bus Client - Client library for connecting to the message bus
-"""
+"""Client for the network based :mod:`macbot.message_bus` server."""
+
+from __future__ import annotations
+
 import json
 import logging
+import socket
 import threading
-import queue
 import time
-from typing import Dict, List, Callable, Any, Optional
-from datetime import datetime
+from typing import Callable, Dict, List, Optional
+
 
 logger = logging.getLogger(__name__)
 
-# Import message_bus with proper relative import to avoid circular imports
-try:
-    from .message_bus import message_bus
-except ImportError:
-    # Fallback for when imported as a standalone module
-    message_bus = None
 
 class MessageBusClient:
-    """Client for connecting to the MacBot message bus"""
+    """Connects to the :class:`~macbot.message_bus.MessageBus` TCP server."""
 
-    def __init__(self, host: str = "localhost", port: int = 8082, service_type: str = "unknown"):
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 8082,
+        service_type: str = "unknown",
+    ) -> None:
         self.host = host
         self.port = port
         self.service_type = service_type
         self.client_id: Optional[str] = None
-        self.message_queue: Optional[queue.Queue] = None
+
+        self.sock: Optional[socket.socket] = None
+        self.file = None
         self.running = False
         self.connected = False
-        self.message_handlers: Dict[str, List[Callable]] = {}
-
-        # Threading
         self.thread: Optional[threading.Thread] = None
 
-        # Connection management
-        self.reconnect_interval = 5
+        self.message_handlers: Dict[str, List[Callable]] = {}
 
-    def start(self):
-        """Start the message bus client"""
-        self.running = True
-        self.client_id = f"{self.service_type}_{int(time.time())}"
-        
-        if message_bus:
-            self.message_queue = message_bus.register_client(self.client_id, self.service_type)
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Connect to the message bus and start listening for messages."""
+        if self.connected:
+            return
+
+        self.client_id = f"{self.service_type}_{int(time.time() * 1000)}"
+        try:
+            self.sock = socket.create_connection((self.host, self.port))
+            self.file = self.sock.makefile(mode="rw", encoding="utf-8")
+
+            # Register with the server
+            self._send_raw(
+                {
+                    "action": "register",
+                    "client_id": self.client_id,
+                    "service_type": self.service_type,
+                }
+            )
+
+            # Wait for acknowledgement
+            self.file.readline()
+
+            self.running = True
             self.connected = True
-            logger.info(f"Message bus client connected for {self.service_type}")
-            
-            # Start message processing thread
-            self.thread = threading.Thread(target=self._process_messages, daemon=True)
+            self.thread = threading.Thread(target=self._listen_loop, daemon=True)
             self.thread.start()
-        else:
-            logger.error("Message bus not available")
+            logger.info("Message bus client connected for %s", self.service_type)
+        except OSError as exc:
+            logger.error("Failed to connect to message bus: %s", exc)
 
-    def stop(self):
-        """Stop the message bus client"""
+    def stop(self) -> None:
+        """Disconnect from the message bus."""
         self.running = False
-        
-        if message_bus and self.client_id:
-            message_bus.unregister_client(self.client_id)
-        
+        self.connected = False
+
+        if self.sock:
+            try:
+                self.sock.close()
+            except OSError:
+                pass
+
         if self.thread:
             self.thread.join(timeout=5)
-        
-        self.connected = False
-        logger.info(f"Message bus client stopped for {self.service_type}")
 
-    def send_message(self, message: dict):
-        """Send a message through the bus"""
-        if not self.connected or not message_bus:
+        logger.info("Message bus client stopped for %s", self.service_type)
+
+    # ------------------------------------------------------------------
+    def _send_raw(self, data: Dict) -> None:
+        if self.file is None:
+            return
+        self.file.write(json.dumps(data) + "\n")
+        self.file.flush()
+
+    def send_message(
+        self,
+        message: Dict,
+        target_client: Optional[str] = None,
+        target_service: Optional[str] = None,
+        broadcast: bool = False,
+    ) -> None:
+        """Send a message through the bus."""
+        if not self.connected:
             logger.warning("Not connected to message bus, message not sent")
             return
-        
-        # Add metadata
-        enriched_message = {
-            **message,
-            'sender_id': self.client_id,
-            'sender_type': self.service_type,
-            'timestamp': datetime.now().isoformat()
+
+        payload: Dict = {
+            "action": "broadcast" if broadcast else "send",
+            "message": message,
         }
-        
-        message_bus.send_message(enriched_message)
+        if target_client:
+            payload["target_client"] = target_client
+        if target_service:
+            payload["target_service"] = target_service
 
-    def is_connected(self) -> bool:
-        """Check if client is connected"""
-        return self.connected
+        self._send_raw(payload)
 
-    def _process_messages(self):
-        """Process incoming messages"""
-        while self.running and self.message_queue:
-            try:
-                # Non-blocking get with timeout
-                message = self.message_queue.get(timeout=0.1)
-                
-                # Handle message
-                self._handle_message(message)
-                
-            except queue.Empty:
-                continue
-            except Exception as e:
-                logger.error(f"Message processing error: {e}")
-
-    def _handle_message(self, message: dict):
-        """Handle incoming message"""
-        message_type = message.get('type', 'unknown')
-        
-        # Call registered handlers
-        if message_type in self.message_handlers:
-            for handler in self.message_handlers[message_type]:
-                try:
-                    handler(message)
-                except Exception as e:
-                    logger.error(f"Error in message handler: {e}")
-        
-        # Log message
-        logger.debug(f"Received message: {message_type}")
-
-    def register_handler(self, message_type: str, handler: Callable):
-        """Register a message handler"""
+    def register_handler(self, message_type: str, handler: Callable) -> None:
         if message_type not in self.message_handlers:
             self.message_handlers[message_type] = []
         self.message_handlers[message_type].append(handler)
 
-    def unregister_handler(self, message_type: str, handler: Callable):
-        """Unregister a message handler"""
+    def unregister_handler(self, message_type: str, handler: Callable) -> None:
         if message_type in self.message_handlers:
             try:
                 self.message_handlers[message_type].remove(handler)
             except ValueError:
                 pass
 
+    # ------------------------------------------------------------------
+    def _listen_loop(self) -> None:
+        assert self.file is not None
+        while self.running:
+            try:
+                line = self.file.readline()
+                if not line:
+                    break
+                data = json.loads(line)
+                if data.get("action") == "message":
+                    self._handle_message(data.get("message", {}))
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Message processing error: %s", exc)
+                break
 
-# Export the main class
-__all__ = ['MessageBusClient']
+        self.connected = False
+
+    def _handle_message(self, message: Dict) -> None:
+        message_type = message.get("type", "unknown")
+        handlers = self.message_handlers.get(message_type, [])
+        for handler in handlers:
+            try:
+                handler(message)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Error in message handler: %s", exc)
+
+
+__all__ = ["MessageBusClient"]
+

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,71 +1,106 @@
 #!/usr/bin/env python3
-"""
-Test script for MacBot Message Bus System
-"""
-import sys
-import os
-import time
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+"""Integration tests for the network based message bus."""
 
-from macbot.message_bus import MessageBus, start_message_bus, stop_message_bus
+from __future__ import annotations
+
+import os
+import sys
+import time
+from multiprocessing import Process, Queue
+
+# Ensure the src directory is importable when tests are run directly
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from macbot.message_bus import start_message_bus, stop_message_bus
 from macbot.message_bus_client import MessageBusClient
 
-def test_message_bus():
-    """Test the message bus system"""
-    print("🧪 Testing MacBot Message Bus System...")
 
-    # Start message bus
-    print("1. Starting message bus server...")
-    bus = start_message_bus(host='localhost', port=8082)
+def _client_process(
+    host: str,
+    port: int,
+    service_type: str,
+    recv_q: Queue | None = None,
+    send: str | None = None,
+    target_service: str | None = None,
+    broadcast: bool = False,
+) -> None:
+    """Helper process that optionally sends and/or receives a message."""
 
-    # Create test clients
-    print("2. Creating test clients...")
-    client1 = MessageBusClient(
-        host='localhost',
-        port=8082,
-        service_type='test_service_1'
+    client = MessageBusClient(host=host, port=port, service_type=service_type)
+    if recv_q is not None:
+        def handler(msg: dict) -> None:
+            recv_q.put(msg["content"])
+
+        client.register_handler("test", handler)
+
+    client.start()
+    time.sleep(0.5)  # allow connection establishment
+
+    if send is not None:
+        client.send_message(
+            {"type": "test", "content": send},
+            target_service=target_service,
+            broadcast=broadcast,
+        )
+
+    time.sleep(1)
+    client.stop()
+
+
+def test_targeted_message() -> None:
+    """Messages addressed to a service type are delivered to that service."""
+    bus = start_message_bus(port=0)
+    port = bus.port
+
+    recv = Queue()
+    receiver = Process(
+        target=_client_process, args=("localhost", port, "receiver", recv)
     )
-    client2 = MessageBusClient(
-        host='localhost',
-        port=8082,
-        service_type='test_service_2'
+    receiver.start()
+    time.sleep(0.5)
+
+    sender = Process(
+        target=_client_process,
+        args=("localhost", port, "sender", None, "hello", "receiver"),
     )
+    sender.start()
 
-    # Start clients
-    print("3. Starting clients...")
-    client1.start()
-    client2.start()
+    assert recv.get(timeout=5) == "hello"
 
-    # Wait for connections
-    time.sleep(3)
-
-    # Test message sending
-    print("4. Testing message exchange...")
-
-    # Client 1 sends message
-    client1.send_message({
-        'type': 'test_message',
-        'content': 'Hello from client 1!',
-        'timestamp': time.time()
-    })
-
-    # Client 2 sends message
-    client2.send_message({
-        'type': 'test_message',
-        'content': 'Hello from client 2!',
-        'timestamp': time.time()
-    })
-
-    # Wait for messages to be processed
-    time.sleep(2)
-
-    print("5. Test completed successfully!")
-    print("✅ Message bus system is working properly")
-
-    # Cleanup
-    client1.stop()
-    client2.stop()
+    sender.join()
+    receiver.join()
     stop_message_bus()
 
-if __name__ == "__main__":
-    test_message_bus()
+
+def test_broadcast_message() -> None:
+    """Broadcast messages are delivered to all connected clients."""
+    bus = start_message_bus(port=0)
+    port = bus.port
+
+    q1 = Queue()
+    q2 = Queue()
+
+    client1 = Process(
+        target=_client_process, args=("localhost", port, "c1", q1)
+    )
+    client2 = Process(
+        target=_client_process, args=("localhost", port, "c2", q2)
+    )
+    client1.start()
+    client2.start()
+    time.sleep(0.5)
+
+    sender = Process(
+        target=_client_process,
+        args=("localhost", port, "sender", None, "hi", None, True),
+    )
+    sender.start()
+
+    assert q1.get(timeout=5) == "hi"
+    assert q2.get(timeout=5) == "hi"
+
+    sender.join()
+    client1.join()
+    client2.join()
+    stop_message_bus()
+


### PR DESCRIPTION
## Summary
- implement TCP-based message bus server with JSON protocol for registering clients, routing, and broadcasting
- add networked MessageBusClient
- verify end-to-end delivery with multiprocessing tests

## Testing
- `pytest tests/test_message_bus.py::test_targeted_message -q`
- `pytest tests/test_message_bus.py::test_broadcast_message -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf3edceec8323a80f2549dc93d541