### PR TITLE
Use reentrant lock in ConversationManager and add deadlock tests

### DIFF
--- a/src/macbot/conversation_manager.py
+++ b/src/macbot/conversation_manager.py
@@ -79,7 +79,10 @@ class ConversationManager:
         self.conversation_history: List[Message] = []
 
         # Thread safety
-        self.lock = threading.Lock()
+        # Use a reentrant lock so that methods can safely call
+        # other lock-protected methods like update_state without
+        # risking deadlocks.
+        self.lock = threading.RLock()
 
         # Callbacks
         self.state_change_callbacks: List[Callable] = []

--- a/tests/test_conversation_manager_rlock.py
+++ b/tests/test_conversation_manager_rlock.py
@@ -1,0 +1,42 @@
+import threading
+import os
+import sys
+
+# Ensure the source directory is on the path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from macbot.conversation_manager import ConversationManager, ConversationState
+
+
+def run_with_timeout(func, timeout=1.0):
+    """Run `func` in a thread and ensure it completes within timeout."""
+    thread = threading.Thread(target=func)
+    thread.start()
+    thread.join(timeout)
+    assert not thread.is_alive(), "Operation deadlocked"
+
+
+def test_interrupt_resume_no_deadlock():
+    """Interrupting and resuming should not deadlock the manager."""
+    cm = ConversationManager()
+    cm.start_conversation()
+    cm.start_response("hello")
+
+    # Interrupt should complete without hanging
+    run_with_timeout(cm.interrupt_response)
+    assert cm.current_context.current_state == ConversationState.INTERRUPTED
+
+    # Resume should also complete without hanging
+    run_with_timeout(lambda: cm.resume_response())
+    assert cm.current_context.current_state == ConversationState.SPEAKING
+
+
+def test_clear_conversation_no_deadlock():
+    """Clearing the conversation should not deadlock."""
+    cm = ConversationManager()
+    cm.start_conversation()
+    cm.start_response("hi")
+    cm.interrupt_response()
+
+    run_with_timeout(cm.clear_conversation)
+    assert cm.current_context is None


### PR DESCRIPTION
## Summary
- switch conversation manager lock to `threading.RLock` to allow nested state updates
- add regression tests for interrupt/resume and clear flows ensuring no deadlock

## Testing
- `pytest tests/test_conversation_manager_rlock.py -q`
- `pytest tests/test_barge_in.py::test_basic_conversation_manager -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4b1724f2483238510acaac9ae66b0