### PR TITLE
Use non-blocking CPU usage check in get_system_info

### DIFF
--- a/src/macbot/tools.py
+++ b/src/macbot/tools.py
@@ -46,7 +46,8 @@ def browse_website(url: str) -> str:
 
 def get_system_info() -> str:
     try:
-        cpu = psutil.cpu_percent(interval=1)
+        # Use non-blocking call to get instantaneous CPU usage
+        cpu = psutil.cpu_percent(interval=None)
         mem = psutil.virtual_memory().percent
         disk = psutil.disk_usage("/").percent
         return f"System Status: CPU {cpu}%, RAM {mem}%, Disk {disk}%"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import time
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from macbot import tools
+
+
+def test_get_system_info_returns_promptly():
+    start = time.perf_counter()
+    info = tools.get_system_info()
+    elapsed = time.perf_counter() - start
+    assert elapsed < 0.5, f"get_system_info took too long: {elapsed}s"
+    assert info.startswith("System Status:"), info


### PR DESCRIPTION
## Summary
- Use `psutil.cpu_percent(interval=None)` for instantaneous CPU measurement in `get_system_info`
- Add unit test ensuring `get_system_info` returns promptly without delay

## Testing
- `pytest tests/test_tools.py -q`
- `pytest tests -q` *(fails: KeyboardInterrupt at `conversation_manager.py:122`)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b183f98483238381fa1459198c1c