### PR TITLE
Implement asynchronous message dispatch in MessageBus

### DIFF
--- a/src/macbot/message_bus.py
+++ b/src/macbot/message_bus.py
@@ -2,11 +2,9 @@
 """
 MacBot Message Bus - Simplified real-time communication system for all services
 """
-import json
 import logging
 import threading
 import queue
-import time
 from typing import Dict, List, Callable, Any, Optional
 from datetime import datetime
 
@@ -82,12 +80,28 @@ class MessageBus:
             if client_id != exclude_client:
                 client_info['message_queue'].put(message)
 
+    def publish(self, message: dict, target_client: Optional[str] = None, target_service: Optional[str] = None):
+        """Enqueue a message for asynchronous dispatch"""
+        self.message_queue.put({
+            'message': message,
+            'target_client': target_client,
+            'target_service': target_service
+        })
+
+    # Alias for backward compatibility / alternative naming
+    enqueue = publish
+
     def _process_messages(self):
         """Process messages in the background"""
         while self.running:
             try:
-                # Process any queued messages (for future use)
-                time.sleep(0.1)
+                item = self.message_queue.get(timeout=0.1)
+                message = item.get('message')
+                target_client = item.get('target_client')
+                target_service = item.get('target_service')
+                self.send_message(message, target_client=target_client, target_service=target_service)
+            except queue.Empty:
+                continue
             except Exception as e:
                 logger.error(f"Message processing error: {e}")
 

--- a/tests/test_message_bus_dispatch.py
+++ b/tests/test_message_bus_dispatch.py
@@ -1,0 +1,28 @@
+from macbot.message_bus import MessageBus
+
+
+def test_publish_to_specific_client():
+    bus = MessageBus()
+    bus.start()
+    try:
+        client_queue = bus.register_client("client1", "serviceA")
+        bus.publish({"type": "test", "content": 123}, target_client="client1")
+        message = client_queue.get(timeout=1)
+        assert message["content"] == 123
+    finally:
+        bus.stop()
+
+
+def test_publish_to_service_type():
+    bus = MessageBus()
+    bus.start()
+    try:
+        q1 = bus.register_client("client1", "serviceA")
+        q2 = bus.register_client("client2", "serviceA")
+        bus.publish({"type": "broadcast", "value": "hi"}, target_service="serviceA")
+        m1 = q1.get(timeout=1)
+        m2 = q2.get(timeout=1)
+        assert m1["value"] == "hi"
+        assert m2["value"] == "hi"
+    finally:
+        bus.stop()


### PR DESCRIPTION
## Summary
- Process queued messages using a blocking queue with timeout
- Add `publish`/`enqueue` API for external message submission
- Test message bus dispatch to specific clients and service types

## Testing
- `PYTHONPATH=src pytest tests/test_message_bus_dispatch.py -q`
- `PYTHONPATH=src pytest tests/test_message_bus.py -q`
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b17c31c483239df6f6be0671a800