### PR TITLE
Encode queries and URLs with urllib.quote

### DIFF
--- a/src/macbot/tools.py
+++ b/src/macbot/tools.py
@@ -13,6 +13,7 @@ from typing import List, Optional
 
 import psutil
 import requests
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from . import config as cfg
 
@@ -23,7 +24,7 @@ def web_search(query: str) -> str:
         return "No search query provided."
     engine = "google"
     base = "https://www.google.com/search?q=" if engine == "google" else "https://duckduckgo.com/?q="
-    url = f"{base}{query.replace(' ', '+')}"
+    url = f"{base}{quote(query)}"
     try:
         subprocess.run(["open", "-a", "Safari", url], check=True)
         return f"Opened Safari to search for '{query}'."
@@ -37,9 +38,18 @@ def browse_website(url: str) -> str:
         return "No URL provided."
     if not url.startswith(("http://", "https://")):
         url = "https://" + url
+
+    parts = urlsplit(url)
+    if not parts.netloc:
+        return "Invalid URL."
+
+    path = quote(parts.path)
+    query = quote(parts.query, safe="=&")
+    fragment = quote(parts.fragment)
+    normalized = urlunsplit((parts.scheme, parts.netloc, path, query, fragment))
     try:
-        subprocess.run(["open", "-a", "Safari", url], check=True)
-        return f"Opened {url} in Safari."
+        subprocess.run(["open", "-a", "Safari", normalized], check=True)
+        return f"Opened {normalized} in Safari."
     except Exception as e:
         return f"Website open failed: {e}"
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from macbot.tools import browse_website, web_search
+
+
+def test_web_search_encodes_query():
+    with patch("macbot.tools.subprocess.run") as mock_run:
+        result = web_search("C++ tips & tricks")
+        expected_url = "https://www.google.com/search?q=C%2B%2B%20tips%20%26%20tricks"
+        mock_run.assert_called_once_with([
+            "open",
+            "-a",
+            "Safari",
+            expected_url,
+        ], check=True)
+        assert "Opened Safari" in result
+
+
+def test_browse_website_encodes_url():
+    with patch("macbot.tools.subprocess.run") as mock_run:
+        result = browse_website("example.com/path with spaces?q=a b#frag ment")
+        expected_url = "https://example.com/path%20with%20spaces?q=a%20b#frag%20ment"
+        mock_run.assert_called_once_with([
+            "open",
+            "-a",
+            "Safari",
+            expected_url,
+        ], check=True)
+        assert result == f"Opened {expected_url} in Safari."


### PR DESCRIPTION
## Summary
- Use urllib.parse.quote for search query encoding
- Validate and normalize URLs with quote in browse_website
- Add tests for search and browse utilities handling spaces and special characters

## Testing
- `PYTHONPATH=src python -m pytest tests/test_tools.py -q`
- `PYTHONPATH=src python -m pytest -q` *(fails: KeyboardInterrupt from conversation_manager)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b1822368832393f32d742d2a0147