### PR TITLE
feat: centralize service startup and add restart API

### DIFF
--- a/src/macbot/static/dashboard.js
+++ b/src/macbot/static/dashboard.js
@@ -135,6 +135,18 @@
   }
   window.updateServiceStatus = updateServiceStatus;
 
+  async function restartService(name) {
+    try {
+      const r = await fetch('/api/service/' + name + '/restart', { method: 'POST' });
+      const data = await r.json();
+      if (!r.ok || !data.success) {
+        console.warn('restart failed', data);
+      }
+      await updateServiceStatus();
+    } catch (e) { console.warn('restart error', e); }
+  }
+  window.restartService = restartService;
+
   function attachListeners() {
     const sendBtn = byId('chat-button');
     const input = byId('chat-input');


### PR DESCRIPTION
## Summary
- add `ServiceDefinition` and generic `start_service` with retry/backoff
- expose `/services` and restart endpoints from orchestrator
- proxy service management through dashboard and add JS helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4bbfd8ab8832389e7826f6b8307a2