### PR TITLE
Add RAG auth header support and tests

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,3 +13,44 @@ def test_get_system_info_returns_promptly():
     elapsed = time.perf_counter() - start
     assert elapsed < 0.5, f"get_system_info took too long: {elapsed}s"
     assert info.startswith("System Status:"), info
+
+
+def test_rag_search_sends_authorization_header(monkeypatch):
+    token = "test-token-123"
+    captured = {}
+
+    def fake_get(url, *args, **kwargs):
+        class _Response:
+            status_code = 200
+
+            def json(self):
+                return {"status": "ok"}
+
+        return _Response()
+
+    def fake_post(url, *args, **kwargs):
+        captured["headers"] = kwargs.get("headers")
+
+        class _Response:
+            status_code = 200
+
+            def json(self):
+                return {
+                    "results": [
+                        {
+                            "metadata": {"title": "Doc"},
+                            "content": "Some relevant content",
+                        }
+                    ]
+                }
+
+        return _Response()
+
+    monkeypatch.setattr(tools.cfg, "get_rag_api_tokens", lambda: [token])
+    monkeypatch.setattr(tools.requests, "get", fake_get)
+    monkeypatch.setattr(tools.requests, "post", fake_post)
+
+    result = tools.rag_search("query")
+
+    assert "Top results" in result
+    assert captured["headers"]["Authorization"] == f"Bearer {token}"


### PR DESCRIPTION
## Summary
- add helper to read configured RAG API token and include it in rag_search requests
- surface clearer authentication failures when tokens are present
- add regression test to ensure Authorization header is sent when a token is configured

## Testing
- pytest tests/test_tools.py

------
https://chatgpt.com/codex/tasks/task_e_68cdda6045dc832388aa7c7bdfbfe9ed