### PR TITLE
Add missing time import to logging utilities

### DIFF
--- a/src/macbot/logging_utils.py
+++ b/src/macbot/logging_utils.py
@@ -15,6 +15,7 @@ import os
 import json
 import uuid
 import traceback
+import time
 from logging.handlers import RotatingFileHandler
 from typing import Dict, Any, Optional
 from datetime import datetime


### PR DESCRIPTION
## Summary
- add the standard-library `time` import required by `log_error_with_context`

## Testing
- PYTHONPATH=src python - <<'PY'
from macbot.logging_utils import setup_logger, log_error_with_context
import logging

logger = setup_logger('test_logger', '/tmp/test.log', structured=False)
try:
    raise ValueError('sample error')
except Exception as e:
    err_id = log_error_with_context(logger, e, component='test_component')
    print('Generated error ID:', err_id)
PY


------
https://chatgpt.com/codex/tasks/task_e_68d1764835ec83239667c696f69538ed