### PR TITLE
Use template for RAG dashboard and escape docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include pyproject.toml
 include README.md
 include ENHANCED_FEATURES.md
 recursive-include docs *.md
+recursive-include src/macbot/templates *.html
 
 # Include scripts
 include *.sh

--- a/src/macbot/templates/rag_dashboard.html
+++ b/src/macbot/templates/rag_dashboard.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MacBot RAG Server</title>
+    <style>
+        body { font-family: -apple-system, sans-serif; margin: 40px; background: #f5f5f7; color: #1d1d1f; }
+        .container { max-width: 900px; margin: 0 auto; }
+        .card { background: white; padding: 20px; margin: 20px 0; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 20px; }
+        .stat { text-align: center; }
+        .stat-value { font-size: 2em; font-weight: bold; color: #007aff; }
+        .doc-item { border: 1px solid #e0e0e0; padding: 15px; margin: 10px 0; border-radius: 6px; background: #fafafa; }
+        .search-box { width: 100%; padding: 10px; margin: 20px 0; border: 1px solid #ccc; border-radius: 4px; }
+        .search-results { margin-top: 20px; }
+        button { padding: 10px 16px; border-radius: 4px; border: none; background: #007aff; color: #fff; cursor: pointer; }
+        button:hover { background: #005bb5; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🤖 MacBot RAG Server</h1>
+
+        <div class="card">
+            <h2>System Statistics</h2>
+            <div class="stats">
+                <div class="stat">
+                    <div class="stat-value">{{ stats.total_documents }}</div>
+                    <div>Documents</div>
+                </div>
+                <div class="stat">
+                    <div class="stat-value">{{ stats.total_chunks }}</div>
+                    <div>Chunks</div>
+                </div>
+                <div class="stat">
+                    <div class="stat-value">{{ stats.embedding_model }}</div>
+                    <div>Model</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h2>Search Documents</h2>
+            <input type="text" class="search-box" id="searchInput" placeholder="Enter your search query...">
+            <button type="button" onclick="search()">Search</button>
+            <div id="searchResults" class="search-results"></div>
+        </div>
+
+        <div class="card">
+            <h2>Available Documents ({{ docs|length }})</h2>
+            {% if docs %}
+                {% for doc in docs %}
+                    <div class="doc-item">
+                        <strong>{{ doc.title }}</strong> ({{ doc.type }}) - {{ doc.length }} chars
+                    </div>
+                {% endfor %}
+            {% else %}
+                <p>No documents available.</p>
+            {% endif %}
+        </div>
+    </div>
+
+    <script>
+    function clearChildren(node) {
+        while (node.firstChild) {
+            node.removeChild(node.firstChild);
+        }
+    }
+
+    function createResultElement(result) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'doc-item';
+
+        const title = document.createElement('strong');
+        title.textContent = (result.metadata && result.metadata.title) || 'Untitled';
+        wrapper.appendChild(title);
+
+        wrapper.appendChild(document.createElement('br'));
+
+        const snippet = document.createElement('span');
+        const content = (result.content || '').substring(0, 200);
+        snippet.textContent = content ? content + '...' : '';
+        wrapper.appendChild(snippet);
+
+        return wrapper;
+    }
+
+    function search() {
+        const query = document.getElementById('searchInput').value;
+        if (!query) return;
+
+        fetch('/api/search', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({query: query})
+        })
+        .then(response => response.json())
+        .then(data => {
+            const resultsDiv = document.getElementById('searchResults');
+            clearChildren(resultsDiv);
+
+            if (data.results && data.results.length > 0) {
+                const heading = document.createElement('h3');
+                heading.textContent = 'Search Results:';
+                resultsDiv.appendChild(heading);
+
+                data.results.forEach(result => {
+                    resultsDiv.appendChild(createResultElement(result));
+                });
+            } else {
+                const empty = document.createElement('p');
+                empty.textContent = 'No results found.';
+                resultsDiv.appendChild(empty);
+            }
+        });
+    }
+    </script>
+</body>
+</html>

--- a/tests/test_rag_server_dashboard.py
+++ b/tests/test_rag_server_dashboard.py
@@ -1,0 +1,72 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from macbot import rag_server as rag_module
+
+
+class DummyRAGServer:
+    def __init__(self):
+        self.documents = {}
+        self.document_metadata = {}
+
+    def add_document(self, content, title, doc_type="text", metadata=None):
+        doc_id = f"doc_{len(self.documents)}"
+        self.documents[doc_id] = content
+        self.document_metadata[doc_id] = {
+            "title": title,
+            "type": doc_type,
+            "added": "2024-01-01T00:00:00",
+            "length": len(content),
+            **(metadata or {}),
+        }
+        return doc_id
+
+    def list_documents(self):
+        return [
+            {
+                "id": doc_id,
+                "title": meta.get("title", "Untitled"),
+                "type": meta.get("type", "unknown"),
+                "added": meta.get("added", ""),
+                "length": meta.get("length", 0),
+            }
+            for doc_id, meta in self.document_metadata.items()
+        ]
+
+    def get_stats(self):
+        count = len(self.documents)
+        return {
+            "total_documents": count,
+            "total_chunks": count,
+            "embedding_model": "test-model",
+            "vector_db": "test-db",
+            "last_updated": "2024-01-01T00:00:00",
+        }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    dummy = DummyRAGServer()
+    monkeypatch.setattr(rag_module, "_rag_server", dummy)
+    with rag_module.app.test_client() as test_client:
+        yield test_client, dummy
+
+
+def test_dashboard_escapes_document_titles(client):
+    test_client, server = client
+    server.add_document(
+        content="<script>alert('content')</script>",
+        title='<script>alert("xss")</script>',
+        doc_type="malicious",
+    )
+
+    response = test_client.get("/")
+    assert response.status_code == 200
+
+    body = response.get_data(as_text=True)
+    assert "&lt;script&gt;alert(&#34;xss&#34;)&lt;/script&gt;" in body
+    assert "<strong><script>alert(\"xss\")</script></strong>" not in body


### PR DESCRIPTION
## Summary
- replace the inline HTML returned by the RAG dashboard with a Flask template backed by a lazily created server instance
- render document metadata through Jinja so titles and snippets are auto-escaped and update the manifest to include templates
- add a regression test that loads a script-tag document and asserts the dashboard shows escaped content

## Testing
- pytest tests/test_rag_server_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d18f7aab9083238ac1f3597821440c