### PR TITLE
Ensure validate_config_silent loads configuration before validation

### DIFF
--- a/src/macbot/config.py
+++ b/src/macbot/config.py
@@ -483,11 +483,13 @@ def get_orchestrator_host_port() -> tuple[str, int]:
 
 def validate_config_silent() -> tuple[bool, List[str]]:
     """Validate configuration without raising exceptions
-    
+
     Returns:
         tuple: (is_valid, list_of_warnings)
     """
     try:
+        if not _LOADED:
+            _load()
         _validate_config(_CFG)
         return True, []
     except ValueError as e:

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import macbot.config as config
+
+
+def test_validate_config_silent_reports_invalid_config(monkeypatch, tmp_path):
+    """validate_config_silent should load the config file before validation."""
+
+    invalid_config_path = tmp_path / "config.yaml"
+    invalid_config_path.write_text(
+        "models:\n"
+        "  llm:\n"
+        "    context_length: -5\n"
+    )
+
+    original_path = config._CONFIG_PATH
+    original_cfg = config._CFG
+    original_loaded = config._LOADED
+
+    monkeypatch.setattr(config, "_CONFIG_PATH", str(invalid_config_path), raising=False)
+
+    config._CFG = {}
+    config._LOADED = False
+
+    is_valid = None
+    warnings = []
+
+    try:
+        is_valid, warnings = config.validate_config_silent()
+    finally:
+        config._CONFIG_PATH = original_path
+        config._CFG = original_cfg
+        config._LOADED = original_loaded
+
+    assert not is_valid
+    assert warnings
+    assert any("models.llm.context_length" in warning for warning in warnings)


### PR DESCRIPTION
## Summary
- call `_load()` when `validate_config_silent` runs without a preloaded configuration so validation uses the real file contents
- add a regression test that verifies invalid configuration files now trigger validation failures even if no getters ran beforehand

## Testing
- `pytest tests/test_config_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1968f6060832397229958d3aa36ec