### PR TITLE
Handle boolean casting in config getters

### DIFF
--- a/src/macbot/config.py
+++ b/src/macbot/config.py
@@ -19,6 +19,9 @@ _CONFIG_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..
 _CFG: Dict[str, Any] = {}
 _LOADED = False
 
+_BOOL_TRUE_VALUES = frozenset({"true", "1", "yes", "y", "on"})
+_BOOL_FALSE_VALUES = frozenset({"false", "0", "no", "n", "off"})
+
 
 def _load() -> None:
     global _CFG, _LOADED
@@ -235,6 +238,25 @@ def get_typed(path: str, default: Any, cast_type: type) -> Any:
         The cast value or default
     """
     val = get(path, default)
+
+    if cast_type is bool:
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, str):
+            normalized = val.strip().lower()
+            if normalized in _BOOL_TRUE_VALUES:
+                return True
+            if normalized in _BOOL_FALSE_VALUES:
+                return False
+            return default
+        try:
+            return bool(val)
+        except (TypeError, ValueError):
+            return default
+
+    if isinstance(val, cast_type):
+        return val
+
     try:
         return cast_type(val)
     except (TypeError, ValueError):

--- a/tests/test_config_bool_parsing.py
+++ b/tests/test_config_bool_parsing.py
@@ -1,0 +1,62 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from macbot import config as cfg
+
+
+def _set_config(monkeypatch: pytest.MonkeyPatch, data: dict) -> None:
+    monkeypatch.setattr(cfg, "_CFG", data, raising=False)
+    monkeypatch.setattr(cfg, "_LOADED", True, raising=False)
+
+
+def test_tts_config_boolean_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {
+        "voice_assistant": {
+            "performance": {
+                "tts_cache_enabled": False,
+                "tts_parallel_processing": True,
+                "tts_optimize_for_speed": False,
+            }
+        }
+    }
+    _set_config(monkeypatch, data)
+
+    assert cfg.get_tts_cache_enabled() is False
+    assert cfg.get_tts_parallel_processing() is True
+    assert cfg.get_tts_optimize_for_speed() is False
+
+
+def test_tts_config_string_boolean_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {
+        "voice_assistant": {
+            "performance": {
+                "tts_cache_enabled": " False ",
+                "tts_parallel_processing": "True",
+                "tts_optimize_for_speed": "0",
+            }
+        }
+    }
+    _set_config(monkeypatch, data)
+
+    assert cfg.get_tts_cache_enabled() is False
+    assert cfg.get_tts_parallel_processing() is True
+    assert cfg.get_tts_optimize_for_speed() is False
+
+
+def test_tts_config_invalid_string_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {
+        "voice_assistant": {
+            "performance": {
+                "tts_cache_enabled": "maybe",
+            }
+        }
+    }
+    _set_config(monkeypatch, data)
+
+    assert cfg.get_tts_cache_enabled() is True
+    assert cfg.get_tts_parallel_processing() is True
+    assert cfg.get_tts_optimize_for_speed() is True


### PR DESCRIPTION
## Summary
- update `config.get_typed` to interpret string values when casting to bool and fall back to defaults on parse failures
- add regression tests covering the TTS boolean helpers for both native YAML booleans and string overrides

## Testing
- pytest tests/test_config_bool_parsing.py

------
https://chatgpt.com/codex/tasks/task_e_68d1969214388323b87a9399c16f1c64