### PR TITLE
Refine streaming transcription buffering

### DIFF
--- a/tests/test_voice_assistant_transcription.py
+++ b/tests/test_voice_assistant_transcription.py
@@ -9,6 +9,11 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 from macbot import voice_assistant as va
 
 
+def _make_chunk(duration_sec, sample_rate=16000, amplitude=0.1):
+    samples = int(duration_sec * sample_rate)
+    return np.full(samples, amplitude, dtype=np.float32)
+
+
 def test_transcribe_cli_reads_cli_output(monkeypatch):
     transcript_text = "mock transcript"
     created_paths = []
@@ -33,3 +38,36 @@ def test_transcribe_cli_reads_cli_output(monkeypatch):
     assert result == transcript_text
     for path in created_paths:
         assert not os.path.exists(path)
+
+
+def test_streaming_transcriber_avoids_reprocessing(monkeypatch):
+    call_sizes = []
+    outputs = ["hello", "world"]
+
+    def fake_transcribe(audio):
+        call_sizes.append(len(audio))
+        return outputs[len(call_sizes) - 1]
+
+    monkeypatch.setattr(va, "transcribe", fake_transcribe)
+
+    transcriber = va.StreamingTranscriber(max_buffer_duration=5.0, sample_rate=16000)
+    transcriber._transcription_interval = 0.0
+
+    assert transcriber.add_chunk(_make_chunk(0.2)) == ""
+    assert call_sizes == []
+
+    delta = transcriber.add_chunk(_make_chunk(0.4))
+    assert delta == "hello"
+    assert call_sizes == [9600]
+
+    delta = transcriber.add_chunk(_make_chunk(0.5))
+    assert delta == "world"
+    assert call_sizes == [9600, 8000]
+
+    assert len(transcriber._segments) == 2
+    assert transcriber._segments[0]["start"] == 0
+    assert transcriber._segments[0]["end"] == 9600
+    assert transcriber._segments[1]["start"] == 9600
+    assert transcriber._segments[1]["end"] == 17600
+
+    assert transcriber.flush() == "hello world"


### PR DESCRIPTION
## Summary
- rework `StreamingTranscriber` to track processed offsets, timestamped segments, and aggressively trim processed buffers
- limit transcription work to newly appended audio windows while stitching text output incrementally
- add tests covering incremental chunk handling to ensure minimal transcribe calls and correct deltas

## Testing
- pytest tests/test_voice_assistant_transcription.py

------
https://chatgpt.com/codex/tasks/task_e_68e4126a72ec8323ba80c14b3282c89a