### PR TITLE
Add configurable SentenceTransformer model handling for RAG server

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,12 @@ models:
       # coreml_path: optimized_models/piper_model.mlpackage
     speed: 1.2
     voice: en_US-amy-medium
+  embedding:
+    sentence_transformer:
+      # Point to a local clone or extracted model directory to stay offline
+      local_path: models/sentence-transformers/all-MiniLM-L6-v2
+      # Optional fallback repo ID if you prefer to download from Hugging Face
+      repo_id: sentence-transformers/all-MiniLM-L6-v2
 performance:
   cpu_limit_percent: 80
   max_concurrent_requests: 3

--- a/docs/ENHANCED_FEATURES.md
+++ b/docs/ENHANCED_FEATURES.md
@@ -40,6 +40,18 @@ MacBot has been significantly enhanced with production-ready security, advanced 
    - **Command**: "search knowledge base for [query]"
    - **Features**: Document ingestion, semantic search, vector database
 
+### Offline Embedding Model Preparation
+
+- **Configuration Keys**: Update `config/config.yaml` under `models.embedding.sentence_transformer`.
+  - `local_path`: Absolute or relative path to a locally cloned/extracted SentenceTransformer model (preferred).
+  - `repo_id`: Optional Hugging Face Hub repo identifier to fall back on when a local copy is unavailable.
+- **Offline Setup Steps**:
+  1. Clone or download the repository containing your embedding model, e.g. `sentence-transformers/all-MiniLM-L6-v2`.
+  2. Place the extracted directory somewhere accessible to MacBot (for example `models/sentence-transformers/all-MiniLM-L6-v2`).
+  3. Set `local_path` in `config/config.yaml` to that directory. Leave `repo_id` empty to fully disable network downloads.
+  4. Restart the RAG server. It will refuse to start if the configured `local_path` is missing, helping you catch typos or incomplete downloads early.
+- **Tip**: If you must rely on `repo_id`, ensure the system has network access or that you've pre-populated the Hugging Face cache directory to stay offline.
+
 ## Web Dashboard Features
 
 ### Real-Time WebSocket Communication

--- a/tests/test_rag_server_api.py
+++ b/tests/test_rag_server_api.py
@@ -34,6 +34,11 @@ def rag_server_client(monkeypatch: pytest.MonkeyPatch) -> Iterator["FlaskClient"
 
     monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "src"))
 
+    import macbot.config as config_module
+
+    monkeypatch.setattr(config_module, "get_sentence_transformer_local_path", lambda: "")
+    monkeypatch.setattr(config_module, "get_sentence_transformer_repo_id", lambda: "sentence-transformers/test-model")
+
     monkeypatch.setitem(sys.modules, "chromadb", types.SimpleNamespace(PersistentClient=DummyPersistentClient))
 
     class DummySentenceTransformer:  # pragma: no cover - simple stub

--- a/tests/test_rag_server_model_loading.py
+++ b/tests/test_rag_server_model_loading.py
@@ -1,0 +1,118 @@
+"""Tests for RAGServer SentenceTransformer loading logic."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+class _DummyCollection:
+    def add(self, *args, **kwargs):  # pragma: no cover - simple stub
+        return None
+
+    def query(self, *args, **kwargs):  # pragma: no cover - simple stub
+        return {"documents": [[]], "ids": [[]], "metadatas": [[]], "distances": [[]]}
+
+    def delete(self, *args, **kwargs):  # pragma: no cover - simple stub
+        return None
+
+
+class _DummyPersistentClient:
+    def __init__(self, *args, **kwargs):  # pragma: no cover - simple stub
+        self._collection = _DummyCollection()
+
+    def get_or_create_collection(self, *args, **kwargs):  # pragma: no cover - simple stub
+        return self._collection
+
+
+def _prepare_rag_import(monkeypatch: pytest.MonkeyPatch, local_path: str, repo_id: str) -> None:
+    """Stub heavy dependencies and configure embedding getters before importing."""
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "src"))
+    import macbot.config as config_module
+
+    monkeypatch.setattr(config_module, "get_sentence_transformer_local_path", lambda: local_path)
+    monkeypatch.setattr(config_module, "get_sentence_transformer_repo_id", lambda: repo_id)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "chromadb",
+        types.SimpleNamespace(PersistentClient=_DummyPersistentClient),
+    )
+
+
+def test_rag_server_prefers_local_sentence_transformer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    local_model_dir = tmp_path / "model"
+    local_model_dir.mkdir()
+
+    calls: dict[str, object] = {}
+
+    class DummySentenceTransformer:  # pragma: no cover - simple stub
+        def __init__(self, model_name_or_path, **kwargs):
+            calls["args"] = (model_name_or_path,)
+            calls["kwargs"] = kwargs
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        types.SimpleNamespace(SentenceTransformer=DummySentenceTransformer),
+    )
+
+    _prepare_rag_import(monkeypatch, str(local_model_dir), "sentence-transformers/fallback")
+
+    sys.modules.pop("macbot.rag_server", None)
+    import macbot.rag_server as rag_module
+
+    assert Path(calls["args"][0]) == local_model_dir
+    assert calls["kwargs"].get("local_files_only") is True
+    assert isinstance(rag_module.rag_server.embedding_model, DummySentenceTransformer)
+
+
+def test_rag_server_missing_local_model_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    missing_dir = tmp_path / "missing"
+
+    class DummySentenceTransformer:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        types.SimpleNamespace(SentenceTransformer=DummySentenceTransformer),
+    )
+
+    _prepare_rag_import(monkeypatch, str(missing_dir), "sentence-transformers/fallback")
+
+    sys.modules.pop("macbot.rag_server", None)
+    with pytest.raises(RuntimeError) as exc:
+        import macbot.rag_server  # noqa: F401
+
+    assert "local_path" in str(exc.value)
+    assert "models.embedding.sentence_transformer.local_path" in str(exc.value)
+
+
+def test_rag_server_uses_repo_when_no_local_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: dict[str, object] = {}
+
+    class DummySentenceTransformer:  # pragma: no cover - simple stub
+        def __init__(self, model_name_or_path, **kwargs):
+            calls["args"] = (model_name_or_path,)
+            calls["kwargs"] = kwargs
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        types.SimpleNamespace(SentenceTransformer=DummySentenceTransformer),
+    )
+
+    _prepare_rag_import(monkeypatch, "", "sentence-transformers/offline-copy")
+
+    sys.modules.pop("macbot.rag_server", None)
+    import macbot.rag_server as rag_module
+
+    assert calls["args"][0] == "sentence-transformers/offline-copy"
+    assert calls["kwargs"].get("local_files_only") is False
+    assert isinstance(rag_module.rag_server.embedding_model, DummySentenceTransformer)
+


### PR DESCRIPTION
## Summary
- add configuration keys and accessors for specifying a local or remote SentenceTransformer embedding model
- update the RAG server to prefer local models, provide helpful errors when files are missing, and avoid downloads unless explicitly configured
- document the offline embedding setup workflow and add tests covering configuration-driven loading behaviour

## Testing
- pytest tests/test_rag_server_model_loading.py tests/test_rag_server_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e4126f809883238bc3e7f4bcb32c1b